### PR TITLE
Arregla antags heads

### DIFF
--- a/modularHispania/code/game/jobs/modularAccess/access_override.dm
+++ b/modularHispania/code/game/jobs/modularAccess/access_override.dm
@@ -152,6 +152,106 @@
 	bio_chips = list(/obj/item/bio_chip/mindshield)
 	return ..()
 
+/datum/game_mode/traitor/
+	protected_jobs = list(
+	"Security Officer",
+	"Warden",
+	"Detective",
+	"Head of Security",
+	"Captain",
+	"Head of Personnel",
+	"Research Director",
+	"Chief Engineer",
+	"Chief Medical Officer",
+	"Blueshield",
+	"Nanotrasen Representative",
+	"Magistrate",
+	"Internal Affairs Agent",
+	"Nanotrasen Navy Officer",
+	"Special Operations Officer",
+	"Quartermaster",
+	"Syndicate Officer")
+
+/datum/game_mode/changeling/
+	protected_jobs = list(
+	"Security Officer",
+	"Warden",
+	"Detective",
+	"Head of Security",
+	"Captain",
+	"Head of Personnel",
+	"Research Director",
+	"Chief Engineer",
+	"Chief Medical Officer",
+	"Blueshield",
+	"Nanotrasen Representative",
+	"Magistrate",
+	"Internal Affairs Agent",
+	"Nanotrasen Navy Officer",
+	"Special Operations Officer",
+	"Quartermaster",
+	"Syndicate Officer")
+
+/datum/game_mode/vampire/
+	protected_jobs = list(
+	"Security Officer",
+	"Warden",
+	"Detective",
+	"Head of Security",
+	"Captain",
+	"Head of Personnel",
+	"Research Director",
+	"Chief Engineer",
+	"Chief Medical Officer",
+	"Blueshield",
+	"Nanotrasen Representative",
+	"Magistrate",
+	"Internal Affairs Agent",
+	"Nanotrasen Navy Officer",
+	"Special Operations Officer",
+	"Quartermaster",
+	"Syndicate Officer")
+
+/datum/game_mode/blob/
+	protected_jobs = list(
+	"Security Officer",
+	"Warden",
+	"Detective",
+	"Head of Security",
+	"Captain",
+	"Head of Personnel",
+	"Research Director",
+	"Chief Engineer",
+	"Chief Medical Officer",
+	"Blueshield",
+	"Nanotrasen Representative",
+	"Magistrate",
+	"Internal Affairs Agent",
+	"Nanotrasen Navy Officer",
+	"Special Operations Officer",
+	"Quartermaster",
+	"Syndicate Officer")
+
+/datum/game_mode/cult/
+	protected_jobs = list(
+	"Security Officer",
+	"Warden",
+	"Detective",
+	"Head of Security",
+	"Captain",
+	"Head of Personnel",
+	"Research Director",
+	"Chief Engineer",
+	"Chief Medical Officer",
+	"Blueshield",
+	"Nanotrasen Representative",
+	"Magistrate",
+	"Internal Affairs Agent",
+	"Nanotrasen Navy Officer",
+	"Special Operations Officer",
+	"Syndicate Officer",
+	"Quartermaster",
+	"Chaplain")
 
 ///The end :)
 


### PR DESCRIPTION
Lo que dice alli. Simple y directo.

Testeado usando 2 cuentas, poniendo ambas como heads en HIGH con traitor on y poniendo ready. No empezaba.
Ponia 1 de esos con otro trabajo no protegido en LOW y voila, aparecio como traitor en ese trabajo que no era head. 